### PR TITLE
Add simple dashboard demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ To generate a production build, run the following command.
 npm run build
 ```
 
+### Demo Dashboard
+
+This repo includes a small dashboard showcasing various Shoelace components.
+Install dependencies and start the demo with the commands below.
+
+```bash
+npm install
+npm run demo
+```
+
+The demo will be served locally with BrowserSync and can be accessed from your
+browser at the printed URL.
+
 ### Creating New Components
 
 To scaffold a new component, run the following command, replacing `sl-tag-name` with the desired tag name.

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html class="sl-theme-light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shoelace Dashboard Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/dist/themes/light.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/dist/shoelace.js"></script>
+  <style>
+    body { margin: 0; display: flex; flex-direction: column; height: 100vh; }
+    header {
+      display: flex;
+      align-items: center;
+      padding: 0 1rem;
+      background-color: var(--sl-color-primary-600);
+      color: var(--sl-color-neutral-0);
+      height: 3.5rem;
+    }
+    header sl-input { max-width: 250px; margin-left: 1rem; }
+    main { display: flex; flex: 1; overflow: hidden; }
+    nav.sidebar {
+      width: 220px;
+      padding: 1rem;
+      background-color: var(--sl-color-neutral-50);
+      border-right: solid 1px var(--sl-color-neutral-200);
+      overflow-y: auto;
+    }
+    section.dashboard {
+      flex: 1;
+      padding: 1rem;
+      overflow-y: auto;
+    }
+    .widgets {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+      gap: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <sl-icon name="layers" style="font-size: 1.25rem; margin-right: 0.5rem;"></sl-icon>
+    <strong>Dashboard</strong>
+    <sl-input placeholder="Search" size="small"></sl-input>
+    <div style="flex: 1;"></div>
+    <sl-icon-button name="bell" label="Notifications"></sl-icon-button>
+    <sl-icon-button name="gear" label="Settings"></sl-icon-button>
+  </header>
+
+  <main>
+    <nav class="sidebar">
+      <sl-menu>
+        <sl-menu-item>Overview</sl-menu-item>
+        <sl-menu-item>Reports</sl-menu-item>
+        <sl-menu-item>Analytics</sl-menu-item>
+        <sl-divider></sl-divider>
+        <sl-menu-item>Settings</sl-menu-item>
+      </sl-menu>
+    </nav>
+    <section class="dashboard">
+      <div class="widgets">
+        <sl-card class="widget">
+          <strong slot="header">Monthly Revenue</strong>
+          <sl-progress-bar value="70"></sl-progress-bar>
+        </sl-card>
+        <sl-card class="widget">
+          <strong slot="header">Active Users</strong>
+          <sl-progress-bar value="85"></sl-progress-bar>
+        </sl-card>
+        <sl-card class="widget">
+          <strong slot="header">Server Load</strong>
+          <sl-progress-ring value="40"></sl-progress-ring>
+        </sl-card>
+        <sl-card class="widget">
+          <strong slot="header">Satisfaction</strong>
+          <sl-rating value="4"></sl-rating>
+        </sl-card>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --max-warnings 0 --fix",
     "create": "plop --plopfile scripts/plop/plopfile.js",
+    "demo": "browser-sync start --server demo --files 'demo'",
     "test": "web-test-runner --group default",
     "test:component": "web-test-runner -- --watch --group",
     "test:watch": "web-test-runner --watch --group default",


### PR DESCRIPTION
## Summary
- add a minimal demo dashboard using Shoelace components
- expose npm script `npm run demo` to serve the demo
- document demo usage in README

## Testing
- `npm test` *(fails: web-test-runner not found)*
- `npm install` *(fails: Exit handler never called)*

------
https://chatgpt.com/codex/tasks/task_b_68492552eafc8329a61804c9d3889f9f